### PR TITLE
JWKSet constructor to accept a Vector of keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ julia:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
+  - 1.5
   - nightly
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "JWTs"
 uuid = "d850fbd6-035d-5a70-a269-1ca2e636ac6c"
 keywords = ["julialang", "jwt", "jwt-authentication", "jwkset", "signing"]
+authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
 license = "MIT"
 desc = "JSON Web Tokens (JWT) for Julia"
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,15 @@ function test_and_get_keyset(url)
     keyset
 end
 
+function test_in_mem_keyset(template)
+    print_header("keyset: $template")
+    keyset = JWKSet(JSON.parse(read(template, String))["keys"])
+    @test length(keyset.keys) == 4
+    for (k,v) in keyset.keys
+        println("    ", k, " => ", v.key)
+    end
+end
+
 function test_signing(keyset_url)
     keyset = test_and_get_keyset(keyset_url)
 
@@ -98,3 +107,4 @@ end
 
 test_and_get_keyset("https://www.googleapis.com/oauth2/v3/certs")
 test_signing("file://" * joinpath(@__DIR__, "jwkkey.json"))
+test_in_mem_keyset(joinpath(@__DIR__, "jwkkey.json"))

--- a/tools/jwt_create.jl
+++ b/tools/jwt_create.jl
@@ -24,7 +24,7 @@ function main()
 
     jwt = JWT(; payload=JSON.parse(readchomp(ARGS[1])))
     sign!(jwt, keyset, kid)
-    println(jwt)
+    println(string(jwt))
 end
 
 main()


### PR DESCRIPTION
This adds a JWKSet constructor to accept a Vector of keys directly (instead of parsing it from a keyset URL).
This can be used to create a JWKSet directly from data generated in-memory.
Added tests for it, and a couple of CI tweaks.