### PR TITLE
add kwarg `default_alg` to refresh!

### DIFF
--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -208,7 +208,7 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_alg = "RS2
                 elseif alg == "RS512"
                     keysetdict[kid] = JWKRSA(MbedTLS.MD_SHA, pubkey(n, e, MbedTLS.MD_SHA))
                 else
-                    @warn("key alg $(key["alg"]) not supported yet, skipping key $kid")
+                    @warn("key alg $alg not supported yet, skipping key $kid")
                     continue
                 end
             elseif kty == "oct"
@@ -220,11 +220,11 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_alg = "RS2
                 elseif alg == "HS512"
                     keysetdict[kid] = JWKSymmetric(MbedTLS.MD_SHA, k)
                 else
-                    @warn("key alg $(key["alg"]) not supported yet, skipping key $kid")
+                    @warn("key alg $alg not supported yet, skipping key $kid")
                     continue
                 end
             else
-                @warn("key type $(key["kty"]) not supported yet, skipping key $kid")
+                @warn("key type $alg not supported yet, skipping key $kid")
                 continue
             end
         catch ex

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -224,7 +224,7 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_alg = "RS2
                     continue
                 end
             else
-                @warn("key type $kty not supported yet, skipping key $kid")
+                @warn("key type $(key["kty"]) not supported yet, skipping key $kid")
                 continue
             end
         catch ex

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -224,7 +224,7 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_alg = "RS2
                     continue
                 end
             else
-                @warn("key type $alg not supported yet, skipping key $kid")
+                @warn("key type $kty not supported yet, skipping key $kid")
                 continue
             end
         catch ex


### PR DESCRIPTION
Currently `refresh!()` fails if a key does not contain an "alg" key.

According to the JWK specification https://www.rfc-editor.org/rfc/rfc7517.html#section-4.4 the alg key is optional, e.g.if only one algorithm is supported.

This is currently the case for Microsoft Azure AD. Therefore, OpenIDConnect fails to validate a token.

I propose to allow for a default_alg value which is taken when no alg key is provided by the key provider. As "RS256" is the default algorithm for OIDC, I'd propose to default `default_alg` to this value.

That way, OpenIDConnect.jl would work out of the box for Azure AD.

But I'd also submit a PR there to explicitly set the value of `default_alg`.
