### PR TITLE
Add `with_valid_jwt` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,19 @@ true
 julia> isvalid(jwt)
 true
 ```
+
+The `with_valid_jwt` method can be used to Run `f` with a valid JWT. The validated JWT is passed as an argument to `f`. If the JWT is invalid, an `ArgumentError` is thrown.
+
+```julia
+julia> with_valid_jwt(jwt2, keyset) do valid_jwt
+           @info("claims", claims(valid_jwt))
+       end
+┌ Info: claims
+│   claims(valid_jwt) =
+│    Dict{String, Any} with 10 entries:
+│      "name"           => "Example User"
+│      "exp"            => 1536080651
+│      "aud"            => "example-audience"
+...
+└      "email"          => "user@example.com"
+```


### PR DESCRIPTION
Added a `with_valid_jwt` exported method for ease of working with validated JWTs. Also updated docstrings of few other methods.

`with_valid_jwt(f, jwt, keyset; kid=nothing)`

Run `f` with a valid JWT. The validated JWT is passed as an argument to `f`. If the JWT is invalid, an `ArgumentError` is thrown.

Arguments:
- `f`: The function to execute with a valid JWT. The validated JWT is passed as an argument to `f`.
- `jwt`: The JWT string or JWT object to use.
- `keyset`: The JWKSet to use for validation. Only keys in this keyset are used for validation.

Keyword arguments:
- `kid`: The key id to use for validation. If not specified, the `kid` from the JWT header is used.