### PR TITLE
fix: seed MersenneTwister using system entropy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["julialang", "jwt", "jwt-authentication", "jwkset", "signing"]
 license = "MIT"
 desc = "JSON Web Tokens (JWT) for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>", "contributors: https://github.com/JuliaWeb/JWTs.jl/graphs/contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -228,7 +228,7 @@ function sign!(jwt::JWT, key::JWK, kid::String="")
     header = urlenc(base64encode(JSON.json(header_dict)))
 
     data = header * "." * jwt.payload
-    sigbytes = key isa JWKRSA ?  MbedTLS.sign(key.key, key.kind, MbedTLS.digest(key.kind, data), MersenneTwister(0)) : MbedTLS.digest(key.kind, data, key.key)
+    sigbytes = key isa JWKRSA ?  MbedTLS.sign(key.key, key.kind, MbedTLS.digest(key.kind, data), MersenneTwister()) : MbedTLS.digest(key.kind, data, key.key)
     signature = urlenc(base64encode(sigbytes))
 
     jwt.header = header


### PR DESCRIPTION
Use the default seeding mechanism of MersenneTwister during signing operations, which seeds it using system entropy. Ref. docstring of MersenneTwister: "If no seed is provided, a randomly generated one is created (using entropy from the system)."

Also bumped Project.toml for tagging a new version