### PR TITLE
Handle http errors when retrieving keys

### DIFF
--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -276,7 +276,15 @@ function refresh!(keyseturl::String, keysetdict::Dict{String,JWK}; default_algs 
         jstr = readchomp(keyseturl[8:end])
     else
         output = PipeBuffer()
-        Downloads.request(keyseturl; method="GET", output=output, downloader=downloader)
+        response = Downloads.request(keyseturl; method="GET", output=output, downloader=downloader)
+
+        # check that we got a valid response. This will avoid giving an "invalid JSON" message if the
+        # response is e.g. "Not found". Note that Downloads.request follows redrects (tested), so if
+        # the actual response is, say, a 301, we will get the 200 from the redirected page.
+        if response.status != 200
+            throw(Downloads.RequestError(keyseturl, response.status, response.message, response))
+        end
+
         jstr = String(take!(output))
     end
     keys = JSON.parse(jstr)["keys"]


### PR DESCRIPTION
Currently, if you construct a JWKSet with a URL that points to e.g. a 404 Not Found, the first sign that anything is amiss is an error from JSON.parse that the JSON is invalid (e.g. if the body of the 404 is just "Not found", it will see the N and think it is processing a null/NaN value and give an error that you have to pass a special argument to parse a NaN). This pull request checks that the response status is 200 before parsing the JSON (`Downloads.request` follows redirects and will give the status from the final request).