### PR TITLE
Typed claims, header, and JWKS document decoding for statically compiled verifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    env:
+      RESEAU_PRECOMPILE_ONLY: ${{ matrix.arch == 'x86' && 'none' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +29,9 @@ jobs:
         include:
           - os: macOS-latest
             arch: aarch64
+            version: 1
+          - os: ubuntu-latest
+            arch: x86
             version: 1
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
           - os: macOS-latest
             arch: aarch64
             version: 1
-          - os: ubuntu-latest
-            arch: x86
-            version: 1
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,13 @@ authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>", "contributors: https://githu
 version = "1.1.0"
 
 [deps]
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-Downloads = "1"
+HTTP = "2"
 JSON = "0.20, 0.21, 1"
 OpenSSL_jll = "3"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 HTTP = "2"
 JSON = "0.20, 0.21, 1"
 OpenSSL_jll = "3"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -119,10 +119,16 @@ Supported verifier options include:
 - `max_age`: maximum token age from `iat`
 - `required_claims`: claims that must be present
 - `now`: injectable clock, useful for deterministic tests
+- `claims`: a concrete payload type for typed decoding and static compilation
+
+In a trim-compiled entrypoint, put the claim type first so normal Julia dispatch
+keeps it concrete: `JWTs.Verifier(MyClaims, keyset; algorithms=["RS256"])`.
+Normal Julia code can also use the `claims=MyClaims` keyword. Typed decoding
+requires JSON.jl 1.
 
 `aud` may be either a string or an array of strings, matching RFC 7519.
 
-`JWTs.VerifiedJWT` exposes the original parsed token as `verified.token`, the decoded header as `verified.header`, the decoded claims as `verified.claims`, and the matched verification key as `verified.key`. The convenience accessors `JWTs.claims(verified)`, `JWTs.kid(verified)`, and `JWTs.alg(verified)` are also available.
+`JWTs.VerifiedJWT` exposes the original parsed token as `verified.token`, the typed `JWTHeaderClaims` header as `verified.header`, the decoded claims as `verified.claims`, and the matched verification key as `verified.key`. The convenience accessors `JWTs.claims(verified)`, `JWTs.kid(verified)`, and `JWTs.alg(verified)` are also available. A verifier rejects JOSE `crit` and `b64` extension headers because this package does not implement extension-header processing.
 
 ## Remote JWKS
 
@@ -150,7 +156,7 @@ fetcher = url -> read("fixtures/jwks.json", String)
 verifier = JWTs.Verifier(; jwks_uri="https://issuer.example/keys", algorithms=["RS256"], fetcher=fetcher)
 ```
 
-The default fetcher uses Downloads.jl. Pass `downloader=Downloads.Downloader()` when you want to reuse a configured Downloads downloader, or pass `fetcher=url -> ...` when tests or applications need full control over network access. The same keywords are available on `JWTs.refresh!(keyset)` for direct `JWKSet` refreshes.
+The default fetcher uses HTTP.jl. Pass `fetcher=url -> ...` when tests or applications need custom transport, authentication, or fixture behavior. The old `downloader` keyword is still accepted so old calls fail with a clear migration error instead of a method error. The same keywords are available on `JWTs.refresh!(keyset)` for direct `JWKSet` refreshes.
 
 ## OpenID Connect Discovery
 

--- a/soleil/Project.toml
+++ b/soleil/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+JWTs = "d850fbd6-035d-5a70-a269-1ca2e636ac6c"
+
+[sources]
+JWTs = {rev = "trim-typed-jwks", url = "https://github.com/JuliaWeb/JWTs.jl"}

--- a/soleil/Project.toml
+++ b/soleil/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-JWTs = "d850fbd6-035d-5a70-a269-1ca2e636ac6c"
-
-[sources]
-JWTs = {rev = "trim-typed-jwks", url = "https://github.com/JuliaWeb/JWTs.jl"}

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -488,16 +488,80 @@ function refresh!(keyset::JWKSet; default_algs = Dict("RSA" => "RS256", "oct" =>
     nothing
 end
 
-function jwks_document(raw, url::String)
+"""
+    JWKSKey
+
+The RFC 7517/7518 JWK members the key-set refresh reads, each an optional
+string. Unknown members (`x5c`, `key_ops`, …) are skipped by the typed parse.
+An entry parsed into this shape is read with concretely typed member accesses
+— a `Dict{String,Any}` element type here would make every member read (and
+the error-display machinery behind `make(::Type{Any})`) dynamic under
+`juliac --trim`.
+"""
+Base.@kwdef struct JWKSKey
+    kid::Union{Nothing,String} = nothing
+    kty::Union{Nothing,String} = nothing
+    alg::Union{Nothing,String} = nothing
+    crv::Union{Nothing,String} = nothing
+    n::Union{Nothing,String} = nothing
+    e::Union{Nothing,String} = nothing
+    k::Union{Nothing,String} = nothing
+    x::Union{Nothing,String} = nothing
+    y::Union{Nothing,String} = nothing
+end
+
+"""
+    JWKSDocument
+
+The RFC 7517 JWK Set document shape: a JSON object with a `keys` array.
+Fetched documents parse into this type rather than an untyped JSON object, so
+the key-set refresh path stays concretely typed — which statically compiled
+(`juliac --trim`) consumers need.
+"""
+Base.@kwdef struct JWKSDocument
+    keys::Union{Nothing,Vector{JWKSKey}} = nothing
+end
+
+# One member of a JWK entry, by its RFC name. Entries arrive either as plain
+# dicts (the public `refresh!(keys::Vector, …)`/`JWKSet(::Vector)` path — the
+# dict reads keep their original KeyError/TypeError behavior) or as the typed
+# `JWKSKey` from a fetched document; call sites pass literal names, so the
+# struct read constant-folds to a field access.
+jwk_member(key::AbstractDict, name::String)::String = key[name]::String
+function jwk_member(key::JWKSKey, name::String)::String
+    value = getfield(key, Symbol(name))
+    value === nothing && throw(KeyError(name))
+    return value
+end
+jwk_optional_member(key::AbstractDict, name::String)::Union{Nothing,String} =
+    haskey(key, name) ? key[name]::String : nothing
+jwk_optional_member(key::JWKSKey, name::String)::Union{Nothing,String} = getfield(key, Symbol(name))
+
+# The `keys` member of a fetched JWKS document, concretely typed. A custom
+# fetcher may hand back an already-parsed object — that arm stays dynamic by
+# design. String and byte documents go through the typed parse on JSON.jl 1,
+# with the untyped read as the pre-1 fallback. (The RemoteJWKSet path has its
+# own `jwks_keys(doc, url)` over pre-parsed documents in remote_jwks.jl.)
+function fetched_jwks_keys(raw, url::String)
     if raw isa AbstractDict
-        return raw
-    elseif raw isa AbstractString
-        return JSON.parse(String(raw))
-    elseif raw isa AbstractVector{UInt8}
-        return JSON.parse(String(raw))
-    else
-        throw(ArgumentError("unsupported JWKS document result from $url: $(typeof(raw))"))
+        keys = get(raw, "keys", nothing)
+        keys isa AbstractVector || throw(ArgumentError("JWKS document from $url must contain a \"keys\" array"))
+        return keys
     end
+    raw isa AbstractString || raw isa AbstractVector{UInt8} ||
+        throw(ArgumentError("unsupported JWKS document result from $url: $(typeof(raw))"))
+    json = String(raw)
+    if applicable(JSON.parse, json, JWKSDocument)
+        document = JSON.parse(json, JWKSDocument)
+        keys = document.keys
+        keys === nothing && throw(ArgumentError("JWKS document from $url must contain a \"keys\" array"))
+        return keys
+    end
+    document = JSON.parse(json)
+    document isa AbstractDict || throw(ArgumentError("JWKS document from $url must be a JSON object"))
+    keys = get(document, "keys", nothing)
+    keys isa AbstractVector || throw(ArgumentError("JWKS document from $url must contain a \"keys\" array"))
+    return keys
 end
 
 # `downloader` is accepted for backwards compatibility and ignored: remote key
@@ -516,24 +580,22 @@ end
 
 function refresh!(keyseturl::String, keysetdict::Dict{String,JWK}; default_algs = Dict("RSA" => "RS256", "oct" => "HS256"), downloader=nothing, fetcher=nothing, allow_symmetric=nothing)
     raw = fetcher === nothing ? fetch_url(keyseturl; downloader=downloader) : fetcher(keyseturl)
-    document = jwks_document(raw, keyseturl)
-    document isa AbstractDict || throw(ArgumentError("JWKS document from $keyseturl must be a JSON object"))
-    keys = get(document, "keys", nothing)
-    keys isa AbstractVector || throw(ArgumentError("JWKS document from $keyseturl must contain a \"keys\" array"))
+    keys = fetched_jwks_keys(raw, keyseturl)
     allow_symmetric = something(allow_symmetric, !is_http_url(keyseturl))
     refresh!(keys, keysetdict; default_algs=default_algs, allow_symmetric=allow_symmetric)
 end
 
-# RFC 7517 JWK members are strings; the `::String` asserts turn each dict
-# lookup from an `Any` that dynamically dispatches every downstream call
-# (JWK construction, base64 decoding, keyset insertion) into a concrete value
-# with statically resolvable calls — required for `juliac --trim` — while a
-# malformed member lands in `refresh!`'s existing per-key skip handling.
-function default_jwk_alg(key::AbstractDict, default_algs::Dict{String,String})::String
-    haskey(key, "alg") && return key["alg"]::String
-    kty = key["kty"]::String
+# RFC 7517 JWK members are strings; reading them through `jwk_member` (a
+# `::String`-asserted dict lookup, or a typed `JWKSKey` field) keeps every
+# downstream call (JWK construction, base64 decoding, keyset insertion)
+# concretely typed — required for `juliac --trim` — while a malformed member
+# lands in `refresh!`'s existing per-key skip handling.
+function default_jwk_alg(key, default_algs::Dict{String,String})::String
+    alg = jwk_optional_member(key, "alg")
+    alg !== nothing && return alg
+    kty = jwk_member(key, "kty")
     if kty in ("EC", "OKP")
-        return alg_for_curve(key["crv"]::String)
+        return alg_for_curve(jwk_member(key, "crv"))
     else
         return get(default_algs, kty, "none")
     end
@@ -542,15 +604,15 @@ end
 function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dict("RSA" => "RS256", "oct" => "HS256"), allow_symmetric::Bool=true)
     default_algs_str = convert(Dict{String,String}, default_algs)
     for key in keys
-        kid = key["kid"]::String
-        kty = key["kty"]::String
+        kid = jwk_member(key, "kid")
+        kty = jwk_member(key, "kty")
         alg = default_jwk_alg(key, default_algs_str)
 
         # ref: https://tools.ietf.org/html/rfc7518
         try
             if kty == "RSA"
-                n = base64url_decode(key["n"]::String)
-                e = base64url_decode(key["e"]::String)
+                n = base64url_decode(jwk_member(key, "n"))
+                e = base64url_decode(jwk_member(key, "e"))
                 if alg in RSA_ALGORITHMS
                     keysetdict[kid] = JWKRSA(alg, rsa_public_key(n, e))
                 else
@@ -562,7 +624,7 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dic
                     @warn("symmetric keys are not accepted from this key source, skipping key $kid")
                     continue
                 end
-                k = base64url_decode(key["k"]::String)
+                k = base64url_decode(jwk_member(key, "k"))
                 if alg in HMAC_ALGORITHMS
                     keysetdict[kid] = JWKSymmetric(alg, k)
                 else
@@ -570,9 +632,9 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dic
                     continue
                 end
             elseif kty == "EC"
-                crv = key["crv"]::String
-                x = base64url_decode(key["x"]::String)
-                y = base64url_decode(key["y"]::String)
+                crv = jwk_member(key, "crv")
+                x = base64url_decode(jwk_member(key, "x"))
+                y = base64url_decode(jwk_member(key, "y"))
                 if alg in EC_ALGORITHMS
                     keysetdict[kid] = JWKEC(alg, ec_public_key(crv, x, y), crv)
                 else
@@ -580,8 +642,8 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dic
                     continue
                 end
             elseif kty == "OKP"
-                crv = key["crv"]::String
-                x = base64url_decode(key["x"]::String)
+                crv = jwk_member(key, "crv")
+                x = base64url_decode(jwk_member(key, "x"))
                 if alg in OKP_ALGORITHMS
                     keysetdict[kid] = JWKOKP(alg, okp_public_key(crv, x), crv)
                 else

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -240,6 +240,7 @@ end
 Base.@kwdef struct JWTHeaderClaims
     alg::Union{Nothing,String} = nothing
     kid::Union{Nothing,String} = nothing
+    typ::Union{Nothing,String} = nothing
 end
 
 function jwt_string_claim(claims::AbstractDict, claim::String)::Union{Nothing,String}
@@ -256,6 +257,19 @@ function jwt_header_string_claim(encoded::String, claim::String)::Union{Nothing,
     claim == "alg" && return header.alg
     claim == "kid" && return header.kid
     return nothing
+end
+
+# Decode a JOSE header into the typed `JWTHeaderClaims`. The typed
+# `JSON.parse` needs JSON.jl 1; older JSON versions read the object
+# dynamically and project the registered members onto the struct.
+function decode_jwt_header_claims(encoded::String)::JWTHeaderClaims
+    applicable(JSON.parse, "", JWTHeaderClaims) && return decodepart(encoded, JWTHeaderClaims)
+    header = decode_jwt_json_object(encoded)
+    return JWTHeaderClaims(
+        alg=jwt_string_claim(header, "alg"),
+        kid=jwt_string_claim(header, "kid"),
+        typ=jwt_string_claim(header, "typ"),
+    )
 end
 
 """

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -508,27 +508,33 @@ function refresh!(keyseturl::String, keysetdict::Dict{String,JWK}; default_algs 
     refresh!(keys, keysetdict; default_algs=default_algs, allow_symmetric=allow_symmetric)
 end
 
-function default_jwk_alg(key, default_algs)
-    haskey(key, "alg") && return key["alg"]
-    kty = key["kty"]
+# RFC 7517 JWK members are strings; the `::String` asserts turn each dict
+# lookup from an `Any` that dynamically dispatches every downstream call
+# (JWK construction, base64 decoding, keyset insertion) into a concrete value
+# with statically resolvable calls — required for `juliac --trim` — while a
+# malformed member lands in `refresh!`'s existing per-key skip handling.
+function default_jwk_alg(key::AbstractDict, default_algs::Dict{String,String})::String
+    haskey(key, "alg") && return key["alg"]::String
+    kty = key["kty"]::String
     if kty in ("EC", "OKP")
-        return alg_for_curve(key["crv"])
+        return alg_for_curve(key["crv"]::String)
     else
         return get(default_algs, kty, "none")
     end
 end
 
 function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dict("RSA" => "RS256", "oct" => "HS256"), allow_symmetric::Bool=true)
+    default_algs_str = convert(Dict{String,String}, default_algs)
     for key in keys
-        kid = key["kid"]
-        kty = key["kty"]
-        alg = default_jwk_alg(key, default_algs)
+        kid = key["kid"]::String
+        kty = key["kty"]::String
+        alg = default_jwk_alg(key, default_algs_str)
 
         # ref: https://tools.ietf.org/html/rfc7518
         try
             if kty == "RSA"
-                n = base64url_decode(key["n"])
-                e = base64url_decode(key["e"])
+                n = base64url_decode(key["n"]::String)
+                e = base64url_decode(key["e"]::String)
                 if alg in RSA_ALGORITHMS
                     keysetdict[kid] = JWKRSA(alg, rsa_public_key(n, e))
                 else
@@ -540,7 +546,7 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dic
                     @warn("symmetric keys are not accepted from this key source, skipping key $kid")
                     continue
                 end
-                k = base64url_decode(key["k"])
+                k = base64url_decode(key["k"]::String)
                 if alg in HMAC_ALGORITHMS
                     keysetdict[kid] = JWKSymmetric(alg, k)
                 else
@@ -548,9 +554,9 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dic
                     continue
                 end
             elseif kty == "EC"
-                crv = key["crv"]
-                x = base64url_decode(key["x"])
-                y = base64url_decode(key["y"])
+                crv = key["crv"]::String
+                x = base64url_decode(key["x"]::String)
+                y = base64url_decode(key["y"]::String)
                 if alg in EC_ALGORITHMS
                     keysetdict[kid] = JWKEC(alg, ec_public_key(crv, x, y), crv)
                 else
@@ -558,8 +564,8 @@ function refresh!(keys::Vector, keysetdict::Dict{String,JWK}; default_algs = Dic
                     continue
                 end
             elseif kty == "OKP"
-                crv = key["crv"]
-                x = base64url_decode(key["x"])
+                crv = key["crv"]::String
+                x = base64url_decode(key["x"]::String)
                 if alg in OKP_ALGORITHMS
                     keysetdict[kid] = JWKOKP(alg, okp_public_key(crv, x), crv)
                 else

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -503,7 +503,10 @@ end
 
 function refresh!(keyseturl::String, keysetdict::Dict{String,JWK}; default_algs = Dict("RSA" => "RS256", "oct" => "HS256"), downloader=nothing, fetcher=nothing, allow_symmetric=nothing)
     raw = fetcher === nothing ? fetch_url(keyseturl; downloader=downloader) : fetcher(keyseturl)
-    keys = jwks_document(raw, keyseturl)["keys"]
+    document = jwks_document(raw, keyseturl)
+    document isa AbstractDict || throw(ArgumentError("JWKS document from $keyseturl must be a JSON object"))
+    keys = get(document, "keys", nothing)
+    keys isa AbstractVector || throw(ArgumentError("JWKS document from $keyseturl must contain a \"keys\" array"))
     allow_symmetric = something(allow_symmetric, !is_http_url(keyseturl))
     refresh!(keys, keysetdict; default_algs=default_algs, allow_symmetric=allow_symmetric)
 end

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -1,7 +1,7 @@
 module JWTs
 
 using JSON
-using Downloads
+using HTTP
 using OpenSSL_jll
 using SHA
 
@@ -486,18 +486,17 @@ function jwks_document(raw, url::String)
     end
 end
 
+# `downloader` is accepted for backwards compatibility and ignored: remote key
+# sets are fetched with HTTP.jl. Pass a `fetcher` to customize retrieval.
 function fetch_url(url::String; downloader=nothing)
     if startswith(url, "file://")
         return readchomp(url[8:end])
     else
-        output = PipeBuffer()
-        response = Downloads.request(url; method="GET", output=output, downloader=downloader)
-        # Downloads.request only throws on transport-level errors, not on HTTP error
-        # status codes, so a 4xx/5xx error page would otherwise be parsed as a keyset.
-        if response isa Downloads.Response && !(200 <= response.status < 300)
+        response = HTTP.get(url; status_exception=false)
+        # A 4xx/5xx error page must not be parsed as a keyset.
+        200 <= response.status < 300 ||
             throw(ErrorException("failed to fetch $url: HTTP status $(response.status)"))
-        end
-        return String(take!(output))
+        return String(response.body)
     end
 end
 

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -283,11 +283,9 @@ function jwt_header_string_claim(encoded::String, claim::String)::Union{Nothing,
     return nothing
 end
 
-# Decode a JOSE header into the typed `JWTHeaderClaims`. The typed
-# `JSON.parse` needs JSON.jl 1; older JSON versions read the object
-# dynamically and project the registered members onto the struct.
-function decode_jwt_header_claims(encoded::String)::JWTHeaderClaims
-    applicable(JSON.parse, "", JWTHeaderClaims) && return decodepart(encoded, JWTHeaderClaims)
+# Project a dynamically parsed header onto the registered JOSE members. Keep
+# this separate so the pre-JSON-1 compatibility path can be tested on JSON 1.
+function decode_jwt_header_claims_untyped(encoded::String)::JWTHeaderClaims
     header = decode_jwt_json_object(encoded)
     return JWTHeaderClaims(
         alg=jwt_string_claim(header, "alg"),
@@ -296,6 +294,14 @@ function decode_jwt_header_claims(encoded::String)::JWTHeaderClaims
         crit=jwt_string_array_claim(header, "crit"),
         b64=jwt_bool_claim(header, "b64"),
     )
+end
+
+# Decode a JOSE header into the typed `JWTHeaderClaims`. The typed
+# `JSON.parse` needs JSON.jl 1; older JSON versions read the object
+# dynamically and project the registered members onto the struct.
+function decode_jwt_header_claims(encoded::String)::JWTHeaderClaims
+    applicable(JSON.parse, "", JWTHeaderClaims) && return decodepart(encoded, JWTHeaderClaims)
+    return decode_jwt_header_claims_untyped(encoded)
 end
 
 """
@@ -583,6 +589,10 @@ function fetched_jwks_keys(raw, url::String)
         keys === nothing && throw(ArgumentError("JWKS document from $url must contain a \"keys\" array"))
         return keys
     end
+    return fetched_jwks_keys_untyped(json, url)
+end
+
+function fetched_jwks_keys_untyped(json::String, url::String)
     document = JSON.parse(json)
     document isa AbstractDict || throw(ArgumentError("JWKS document from $url must be a JSON object"))
     keys = get(document, "keys", nothing)

--- a/src/JWTs.jl
+++ b/src/JWTs.jl
@@ -27,6 +27,7 @@ if VERSION >= v"1.11"
         :JWKSError,
         :parse_keyfile,
         :claims,
+        :claimstype,
         :kid,
         :alg,
         :issigned,
@@ -241,11 +242,34 @@ Base.@kwdef struct JWTHeaderClaims
     alg::Union{Nothing,String} = nothing
     kid::Union{Nothing,String} = nothing
     typ::Union{Nothing,String} = nothing
+    crit::Union{Nothing,Missing,Vector{String}} = nothing
+    b64::Union{Nothing,Missing,Bool} = nothing
 end
 
 function jwt_string_claim(claims::AbstractDict, claim::String)::Union{Nothing,String}
     value = get(claims, claim, nothing)
     value isa String || return nothing
+    return value
+end
+
+function jwt_string_array_claim(claims::AbstractDict, claim::String)::Union{Nothing,Missing,Vector{String}}
+    haskey(claims, claim) || return nothing
+    value = claims[claim]
+    value === nothing && return missing
+    value isa AbstractVector || throw(ArgumentError("jwt header $claim must be an array of strings"))
+    result = String[]
+    for item in value
+        item isa AbstractString || throw(ArgumentError("jwt header $claim must be an array of strings"))
+        push!(result, String(item))
+    end
+    return result
+end
+
+function jwt_bool_claim(claims::AbstractDict, claim::String)::Union{Nothing,Missing,Bool}
+    haskey(claims, claim) || return nothing
+    value = claims[claim]
+    value === nothing && return missing
+    value isa Bool || throw(ArgumentError("jwt header $claim must be a boolean"))
     return value
 end
 
@@ -269,6 +293,8 @@ function decode_jwt_header_claims(encoded::String)::JWTHeaderClaims
         alg=jwt_string_claim(header, "alg"),
         kid=jwt_string_claim(header, "kid"),
         typ=jwt_string_claim(header, "typ"),
+        crit=jwt_string_array_claim(header, "crit"),
+        b64=jwt_bool_claim(header, "b64"),
     )
 end
 
@@ -564,9 +590,9 @@ function fetched_jwks_keys(raw, url::String)
     return keys
 end
 
-# `downloader` is accepted for backwards compatibility and ignored: remote key
-# sets are fetched with HTTP.jl. Pass a `fetcher` to customize retrieval.
 function fetch_url(url::String; downloader=nothing)
+    downloader === nothing || throw(ArgumentError(
+        "the downloader keyword is not supported by the HTTP.jl fetch path; pass fetcher=url -> ... instead"))
     if startswith(url, "file://")
         return readchomp(url[8:end])
     else

--- a/src/verifier.jl
+++ b/src/verifier.jl
@@ -1,7 +1,10 @@
 const VerifierKeySource = Union{JWKSet,RemoteJWKSet,OIDCDiscovery}
 
-struct Verifier
-    keyset::VerifierKeySource
+# Parametric on the key source and clock so a verifier built over a static
+# keyset never makes the remote-JWKS refresh machinery statically reachable
+# (and `now()` stays a direct call) — required for juliac --trim consumers.
+struct Verifier{S<:VerifierKeySource, F}
+    keyset::S
     algorithms::Vector{String}
     issuer::Union{Nothing,String}
     audiences::Union{Nothing,Vector{String}}
@@ -11,7 +14,7 @@ struct Verifier
     leeway::Float64
     max_age::Union{Nothing,Float64}
     required_claims::Vector{String}
-    now::Function
+    now::F
 end
 
 struct VerifiedJWT

--- a/src/verifier.jl
+++ b/src/verifier.jl
@@ -57,6 +57,7 @@ function normalize_required_claims(required_claims)
 end
 
 function Verifier(
+    ::Type{C},
     keyset::VerifierKeySource;
     algorithms=nothing,
     issuer::Union{Nothing,AbstractString}=nothing,
@@ -68,8 +69,8 @@ function Verifier(
     max_age::Union{Nothing,Real}=nothing,
     required_claims=String[],
     now=time,
-    claims::Type=Dict{String,Any},
-)
+) where {C}
+    isconcretetype(C) || throw(ArgumentError("Verifier claims type must be concrete, got $C"))
     algorithms === nothing && throw(ArgumentError("Verifier requires an explicit algorithms allowlist"))
     algs = String[String(alg) for alg in algorithms]
     isempty(algs) && throw(ArgumentError("Verifier requires a non-empty algorithms allowlist"))
@@ -90,7 +91,37 @@ function Verifier(
         max_age === nothing ? nothing : Float64(max_age),
         normalize_required_claims(required_claims),
         normalize_now_function(now),
+        C,
+    )
+end
+
+function Verifier(
+    keyset::VerifierKeySource;
+    algorithms=nothing,
+    issuer::Union{Nothing,AbstractString}=nothing,
+    audience=nothing,
+    subject::Union{Nothing,AbstractString}=nothing,
+    jwtid::Union{Nothing,AbstractString}=nothing,
+    nonce::Union{Nothing,AbstractString}=nothing,
+    leeway::Real=0,
+    max_age::Union{Nothing,Real}=nothing,
+    required_claims=String[],
+    now=time,
+    claims::Type=Dict{String,Any},
+)
+    return Verifier(
         claims,
+        keyset;
+        algorithms,
+        issuer,
+        audience,
+        subject,
+        jwtid,
+        nonce,
+        leeway,
+        max_age,
+        required_claims,
+        now,
     )
 end
 
@@ -98,10 +129,14 @@ end
 # Explicit forwarding (not `kwargs...` splatting) so the call resolves to
 # the keyset constructor alone: with a splat, inference unions this over
 # every keyword `Verifier` method, and the result type is no longer concrete.
+Verifier(::Type{C}, keys::Vector; algorithms=nothing, issuer=nothing, audience=nothing, subject=nothing, jwtid=nothing, nonce=nothing, leeway::Real=0, max_age=nothing, required_claims=String[], now=time) where {C} =
+    Verifier(C, JWKSet(keys); algorithms, issuer, audience, subject, jwtid, nonce, leeway, max_age, required_claims, now)
+
 Verifier(keys::Vector; algorithms=nothing, issuer=nothing, audience=nothing, subject=nothing, jwtid=nothing, nonce=nothing, leeway::Real=0, max_age=nothing, required_claims=String[], now=time, claims::Type=Dict{String,Any}) =
-    Verifier(JWKSet(keys); algorithms, issuer, audience, subject, jwtid, nonce, leeway, max_age, required_claims, now, claims)
+    Verifier(claims, keys; algorithms, issuer, audience, subject, jwtid, nonce, leeway, max_age, required_claims, now)
 
 function Verifier(
+    ::Type{C},
     issuer_url::AbstractString;
     discovery_path::AbstractString="/.well-known/openid-configuration",
     metadata_ttl::Real=300,
@@ -119,7 +154,7 @@ function Verifier(
     leeway::Real=0,
     max_age::Union{Nothing,Real}=nothing,
     required_claims=String[],
-)
+) where {C}
     issuer_s = String(rstrip(String(issuer_url), '/'))
     source = OIDCDiscovery(
         issuer_s;
@@ -133,6 +168,7 @@ function Verifier(
         now=now,
     )
     return Verifier(
+        C,
         source;
         algorithms=algorithms,
         issuer=issuer_s,
@@ -164,7 +200,90 @@ function Verifier(;
     leeway::Real=0,
     max_age::Union{Nothing,Real}=nothing,
     required_claims=String[],
+    claims::Type=Dict{String,Any},
 )
+    return Verifier(
+        claims;
+        jwks_uri,
+        jwks_ttl,
+        refresh_cooldown,
+        default_algs,
+        fetcher,
+        downloader,
+        now,
+        algorithms,
+        issuer,
+        audience,
+        subject,
+        jwtid,
+        nonce,
+        leeway,
+        max_age,
+        required_claims,
+    )
+end
+
+function Verifier(
+    issuer_url::AbstractString;
+    discovery_path::AbstractString="/.well-known/openid-configuration",
+    metadata_ttl::Real=300,
+    jwks_ttl::Real=300,
+    refresh_cooldown::Real=30,
+    default_algs=DEFAULT_JWK_ALGS,
+    fetcher=nothing,
+    downloader=nothing,
+    now=time,
+    algorithms=nothing,
+    audience=nothing,
+    subject::Union{Nothing,AbstractString}=nothing,
+    jwtid::Union{Nothing,AbstractString}=nothing,
+    nonce::Union{Nothing,AbstractString}=nothing,
+    leeway::Real=0,
+    max_age::Union{Nothing,Real}=nothing,
+    required_claims=String[],
+    claims::Type=Dict{String,Any},
+)
+    return Verifier(
+        claims,
+        issuer_url;
+        discovery_path,
+        metadata_ttl,
+        jwks_ttl,
+        refresh_cooldown,
+        default_algs,
+        fetcher,
+        downloader,
+        now,
+        algorithms,
+        audience,
+        subject,
+        jwtid,
+        nonce,
+        leeway,
+        max_age,
+        required_claims,
+    )
+end
+
+function Verifier(
+    ::Type{C};
+    jwks_uri=nothing,
+    jwks_ttl::Real=300,
+    refresh_cooldown::Real=30,
+    default_algs=DEFAULT_JWK_ALGS,
+    fetcher=nothing,
+    downloader=nothing,
+    now=time,
+    algorithms=nothing,
+    issuer::Union{Nothing,AbstractString}=nothing,
+    audience=nothing,
+    subject::Union{Nothing,AbstractString}=nothing,
+    jwtid::Union{Nothing,AbstractString}=nothing,
+    nonce::Union{Nothing,AbstractString}=nothing,
+    leeway::Real=0,
+    max_age::Union{Nothing,Real}=nothing,
+    required_claims=String[],
+) where {C}
     jwks_uri === nothing && throw(ArgumentError("Verifier requires a JWKSet, key vector, OIDC issuer, or jwks_uri"))
     source = RemoteJWKSet(
         jwks_uri;
@@ -176,6 +295,7 @@ function Verifier(;
         now=now,
     )
     return Verifier(
+        C,
         source;
         algorithms=algorithms,
         issuer=issuer,
@@ -205,8 +325,8 @@ function claim_string(claimset, name::String)
 end
 
 function claim_audiences(claimset)
+    hasclaim(claimset, "aud") || throw(JWTClaimError(:claim_missing, "jwt missing required claim aud"))
     value = claimvalue(claimset, "aud")
-    value === nothing && throw(JWTClaimError(:claim_missing, "jwt missing required claim aud"))
     # JSON claims are concrete String / Vector{Any}; narrowing to those (not
     # AbstractString / AbstractVector) keeps the loop statically dispatched.
     value isa String && return String[value]
@@ -231,12 +351,13 @@ decode_claims(encoded::String, ::Type{Dict{String,Any}}) = decode_jwt_json_objec
 decode_claims(encoded::String, ::Type{C}) where {C} = decodepart(encoded, C)
 
 claimvalue(claims::AbstractDict, name::String) = get(claims, name, nothing)
-function claimvalue(claims::T, name::String) where {T}
-    sym = Symbol(name)
-    return hasfield(T, sym) ? getfield(claims, sym) : nothing
+@generated function claimvalue(claims::T, name::String) where {T}
+    reads = [:(name == $(String(field)) && return getfield(claims, $(QuoteNode(field))))
+             for field in fieldnames(T)]
+    return Expr(:block, reads..., :(return nothing))
 end
 hasclaim(claims::AbstractDict, name::String) = haskey(claims, name)
-hasclaim(claims::T, name::String) where {T} = (sym = Symbol(name); hasfield(T, sym) && getfield(claims, sym) !== nothing)
+hasclaim(claims::T, name::String) where {T} = claimvalue(claims, name) !== nothing
 
 function require_claims!(claimset, required_claims)
     for claim in required_claims
@@ -306,6 +427,14 @@ function verify(verifier::Verifier, jwt::JWT)
     header_alg in verifier.algorithms || throw(JWTVerificationError(:algorithm_disallowed, "jwt algorithm is not allowed"))
     header_kid = header.kid
     header_kid === nothing && throw(JWTVerificationError(:key_id_missing, "jwt header does not include kid"))
+    header.crit === nothing || throw(JWTVerificationError(
+        :critical_header_unsupported,
+        "jwt uses critical JOSE header parameters that this verifier does not support",
+    ))
+    header.b64 === nothing || throw(JWTVerificationError(
+        :critical_header_unsupported,
+        "jwt uses the unsupported JOSE b64 header parameter",
+    ))
     key = resolve_verification_key(verifier.keyset, header_kid)
     valid = validate!(jwt, key; algorithms=verifier.algorithms)
     valid || throw(JWTVerificationError(:signature_invalid, "invalid jwt signature"))

--- a/src/verifier.jl
+++ b/src/verifier.jl
@@ -187,15 +187,18 @@ end
 function claim_audiences(claimset)
     haskey(claimset, "aud") || throw(JWTClaimError(:claim_missing, "jwt missing required claim aud"))
     value = claimset["aud"]
-    value isa AbstractString && return String[String(value)]
-    if value isa AbstractVector
+    # JSON claims are concrete String / Vector{Any}; narrowing to those (not
+    # AbstractString / AbstractVector) keeps the loop statically dispatched.
+    value isa String && return String[value]
+    if value isa Vector
         audiences = String[]
         for aud in value
-            aud isa AbstractString || throw(JWTClaimError(:claim_type, "jwt claim aud entries must be strings"))
-            push!(audiences, String(aud))
+            aud isa String || throw(JWTClaimError(:claim_type, "jwt claim aud entries must be strings"))
+            push!(audiences, aud)
         end
         return audiences
     end
+    value isa AbstractString && return String[String(value)]
     throw(JWTClaimError(:claim_type, "jwt claim aud must be a string or array of strings"))
 end
 

--- a/src/verifier.jl
+++ b/src/verifier.jl
@@ -3,7 +3,12 @@ const VerifierKeySource = Union{JWKSet,RemoteJWKSet,OIDCDiscovery}
 # Parametric on the key source and clock so a verifier built over a static
 # keyset never makes the remote-JWKS refresh machinery statically reachable
 # (and `now()` stays a direct call) — required for juliac --trim consumers.
-struct Verifier{S<:VerifierKeySource, F}
+# `C` is the type the payload is decoded into: `Dict{String,Any}` by default
+# (an open claim set, read dynamically), or an application-declared claims
+# struct passed as `Verifier(...; claims=MyClaims)`, decoded with
+# `JSON.parse(payload, MyClaims)` so every claim read is a typed field access
+# — the shape a statically compiled (`juliac --trim`) verifier needs.
+struct Verifier{S<:VerifierKeySource, F, C}
     keyset::S
     algorithms::Vector{String}
     issuer::Union{Nothing,String}
@@ -15,12 +20,20 @@ struct Verifier{S<:VerifierKeySource, F}
     max_age::Union{Nothing,Float64}
     required_claims::Vector{String}
     now::F
+    claims::Type{C}
 end
 
-struct VerifiedJWT
+"""
+    JWTs.claimstype(verifier::Verifier) -> Type
+
+The type a verifier decodes token payloads into (`Dict{String,Any}` by default).
+"""
+claimstype(::Verifier{S,F,C}) where {S,F,C} = C
+
+struct VerifiedJWT{C}
     token::JWT
-    header::JWTJSONDict
-    claims::JWTJSONDict
+    header::JWTHeaderClaims
+    claims::C
     kid::String
     alg::String
     key::JWK
@@ -55,6 +68,7 @@ function Verifier(
     max_age::Union{Nothing,Real}=nothing,
     required_claims=String[],
     now=time,
+    claims::Type=Dict{String,Any},
 )
     algorithms === nothing && throw(ArgumentError("Verifier requires an explicit algorithms allowlist"))
     algs = String[String(alg) for alg in algorithms]
@@ -76,10 +90,16 @@ function Verifier(
         max_age === nothing ? nothing : Float64(max_age),
         normalize_required_claims(required_claims),
         normalize_now_function(now),
+        claims,
     )
 end
 
-Verifier(keys::Vector; kwargs...) = Verifier(JWKSet(keys); kwargs...)
+
+# Explicit forwarding (not `kwargs...` splatting) so the call resolves to
+# the keyset constructor alone: with a splat, inference unions this over
+# every keyword `Verifier` method, and the result type is no longer concrete.
+Verifier(keys::Vector; algorithms=nothing, issuer=nothing, audience=nothing, subject=nothing, jwtid=nothing, nonce=nothing, leeway::Real=0, max_age=nothing, required_claims=String[], now=time, claims::Type=Dict{String,Any}) =
+    Verifier(JWKSet(keys); algorithms, issuer, audience, subject, jwtid, nonce, leeway, max_age, required_claims, now, claims)
 
 function Verifier(
     issuer_url::AbstractString;
@@ -171,22 +191,22 @@ function Verifier(;
 end
 
 function claim_number(claimset, name::String)
-    value = get(claimset, name, nothing)
+    value = claimvalue(claimset, name)
     value isa Bool && throw(JWTClaimError(:claim_type, "jwt claim $name must be numeric"))
     value isa Real && return Float64(value)
     throw(JWTClaimError(:claim_type, "jwt claim $name must be numeric"))
 end
 
 function claim_string(claimset, name::String)
-    haskey(claimset, name) || throw(JWTClaimError(:claim_missing, "jwt missing required claim $name"))
-    value = claimset[name]
+    hasclaim(claimset, name) || throw(JWTClaimError(:claim_missing, "jwt missing required claim $name"))
+    value = claimvalue(claimset, name)
     value isa AbstractString && return String(value)
     throw(JWTClaimError(:claim_type, "jwt claim $name must be a string"))
 end
 
 function claim_audiences(claimset)
-    haskey(claimset, "aud") || throw(JWTClaimError(:claim_missing, "jwt missing required claim aud"))
-    value = claimset["aud"]
+    value = claimvalue(claimset, "aud")
+    value === nothing && throw(JWTClaimError(:claim_missing, "jwt missing required claim aud"))
     # JSON claims are concrete String / Vector{Any}; narrowing to those (not
     # AbstractString / AbstractVector) keeps the loop statically dispatched.
     value isa String && return String[value]
@@ -202,9 +222,25 @@ function claim_audiences(claimset)
     throw(JWTClaimError(:claim_type, "jwt claim aud must be a string or array of strings"))
 end
 
+# Read one claim from a decoded claim set: a dict lookup, or the field of an
+# application-declared claims struct (`nothing` when absent / no such field).
+# Everything below reads claims only through this seam and `hasclaim`, so a
+# typed claim set flows through validation with concrete field types.
+# Decode a payload into the verifier's claims type.
+decode_claims(encoded::String, ::Type{Dict{String,Any}}) = decode_jwt_json_object(encoded)
+decode_claims(encoded::String, ::Type{C}) where {C} = decodepart(encoded, C)
+
+claimvalue(claims::AbstractDict, name::String) = get(claims, name, nothing)
+function claimvalue(claims::T, name::String) where {T}
+    sym = Symbol(name)
+    return hasfield(T, sym) ? getfield(claims, sym) : nothing
+end
+hasclaim(claims::AbstractDict, name::String) = haskey(claims, name)
+hasclaim(claims::T, name::String) where {T} = (sym = Symbol(name); hasfield(T, sym) && getfield(claims, sym) !== nothing)
+
 function require_claims!(claimset, required_claims)
     for claim in required_claims
-        haskey(claimset, claim) || throw(JWTClaimError(:claim_missing, "jwt missing required claim $claim"))
+        hasclaim(claimset, claim) || throw(JWTClaimError(:claim_missing, "jwt missing required claim $claim"))
     end
     return nothing
 end
@@ -212,15 +248,15 @@ end
 function validate_time_claims!(claimset, verifier::Verifier, now_value::Real)
     now_s = Float64(now_value)
     leeway = verifier.leeway
-    if haskey(claimset, "exp")
+    if hasclaim(claimset, "exp")
         exp = claim_number(claimset, "exp")
         now_s <= exp + leeway || throw(JWTClaimError(:token_expired, "jwt expired"))
     end
-    if haskey(claimset, "nbf")
+    if hasclaim(claimset, "nbf")
         nbf = claim_number(claimset, "nbf")
         now_s + leeway >= nbf || throw(JWTClaimError(:token_not_yet_valid, "jwt not yet valid"))
     end
-    if haskey(claimset, "iat")
+    if hasclaim(claimset, "iat")
         iat = claim_number(claimset, "iat")
         now_s + leeway >= iat || throw(JWTClaimError(:token_issued_in_future, "jwt issued in the future"))
         if verifier.max_age !== nothing
@@ -239,9 +275,11 @@ function validate_expected_claims!(claimset, verifier::Verifier)
     verifier.subject === nothing || claim_string(claimset, "sub") == verifier.subject || throw(JWTClaimError(:claim_mismatch, "jwt subject mismatch"))
     verifier.jwtid === nothing || claim_string(claimset, "jti") == verifier.jwtid || throw(JWTClaimError(:claim_mismatch, "jwt id mismatch"))
     verifier.nonce === nothing || claim_string(claimset, "nonce") == verifier.nonce || throw(JWTClaimError(:claim_mismatch, "jwt nonce mismatch"))
-    if verifier.audiences !== nothing
+    expected_audiences = verifier.audiences
+    if expected_audiences !== nothing
         actual = claim_audiences(claimset)
-        any(aud -> aud in verifier.audiences, actual) || throw(JWTClaimError(:claim_mismatch, "jwt audience mismatch"))
+        # capture the narrowed local, not the Union{Nothing,...} field
+        any(aud -> aud in expected_audiences, actual) || throw(JWTClaimError(:claim_mismatch, "jwt audience mismatch"))
     end
     return nothing
 end
@@ -258,21 +296,21 @@ verify(verifier::Verifier, jwt::String) = verify(verifier, JWT(jwt))
 function verify(verifier::Verifier, jwt::JWT)
     issigned(jwt) || throw(JWTVerificationError(:token_unsigned, "jwt is not signed"))
     header = try
-        decode_jwt_json_object(jwt.header)
+        decode_jwt_header_claims(jwt.header)
     catch err
         err isa JWTError && rethrow()
         throw(JWTVerificationError(:malformed_header, "jwt header is not valid base64url-encoded JSON"))
     end
-    header_alg = jwt_string_claim(header, "alg")
+    header_alg = header.alg
     header_alg === nothing && throw(JWTVerificationError(:algorithm_missing, "jwt header does not include alg"))
     header_alg in verifier.algorithms || throw(JWTVerificationError(:algorithm_disallowed, "jwt algorithm is not allowed"))
-    header_kid = jwt_string_claim(header, "kid")
+    header_kid = header.kid
     header_kid === nothing && throw(JWTVerificationError(:key_id_missing, "jwt header does not include kid"))
     key = resolve_verification_key(verifier.keyset, header_kid)
     valid = validate!(jwt, key; algorithms=verifier.algorithms)
     valid || throw(JWTVerificationError(:signature_invalid, "invalid jwt signature"))
     claimset = try
-        decode_jwt_json_object(jwt.payload)
+        decode_claims(jwt.payload, claimstype(verifier))
     catch err
         err isa JWTError && rethrow()
         throw(JWTClaimError(:malformed_payload, "jwt payload is not valid base64url-encoded JSON"))

--- a/test/jwt_trim_core.jl
+++ b/test/jwt_trim_core.jl
@@ -74,6 +74,22 @@ function run_jwt_trim_core()::Nothing
     trim_check_claims(JWTs.claims(parsed, TrimClaims))
     trim_check_signature(parsed, keyset.keys[TRIM_KID])
 
+    verifier = JWTs.Verifier(
+        TrimClaims,
+        keyset;
+        algorithms=["HS256"],
+        issuer=TRIM_ISSUER,
+        audience=TRIM_AUDIENCE,
+        subject=TRIM_SUBJECT,
+        jwtid=TRIM_JWT_ID,
+        nonce=TRIM_NONCE,
+        required_claims=["iat", "nbf", "exp"],
+        now=() -> 1_500.0,
+    )
+    verified = JWTs.verify(verifier, token)
+    JWTs.claimstype(verifier) === TrimClaims || error("typed verifier claim type mismatch")
+    trim_check_claims(JWTs.claims(verified))
+
     imported_keyset = JWTs.JWKSet([trim_oct_jwk()])
     JWTs.validate!(parsed, imported_keyset.keys[TRIM_KID]; algorithms=["HS256"]) ||
         error("key-set validation failed")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,17 @@ const test_payload_data = [
     }""")
 ]
 
+Base.@kwdef struct VerifierTestClaims
+    iss::Union{Nothing,String} = nothing
+    sub::Union{Nothing,String} = nothing
+    aud::Union{Nothing,String,Vector{String}} = nothing
+    exp::Union{Nothing,Int64} = nothing
+    nbf::Union{Nothing,Int64} = nothing
+    iat::Union{Nothing,Int64} = nothing
+    jti::Union{Nothing,String} = nothing
+    nonce::Union{Nothing,String} = nothing
+end
+
 struct TypedTestClaims
     sub::String
     exp::Int64
@@ -413,12 +424,39 @@ function test_verifier_claims(keyset_url)
 
     verified = verify(verifier, string(jwt))
     @test verified.token isa JWT
-    @test verified.header["typ"] == "JWT"
+    @test verified.header.typ == "JWT"
     @test JWTs.claims(verified) == base_payload
     @test JWTs.kid(verified) == keyid
     @test JWTs.alg(verified) == algorithm
     @test verified.key === keyset.keys[keyid]
     @test verify(verifier, jwt).claims == base_payload
+
+    # An application-declared claims struct: the payload is decoded straight
+    # into it and every validation read is a typed field access.
+    if applicable(JSON.parse, "", VerifierTestClaims)
+        typed_verifier = Verifier(
+            keyset;
+            algorithms=[algorithm],
+            issuer="https://issuer.example",
+            audience="api://default",
+            subject="subject-1",
+            jwtid="token-1",
+            nonce="nonce-1",
+            required_claims=["exp", "nbf", "iat"],
+            now=() -> 1000.0,
+            claims=VerifierTestClaims,
+        )
+        @test JWTs.claimstype(typed_verifier) === VerifierTestClaims
+        typed_verified = verify(typed_verifier, string(jwt))
+        @test typed_verified isa JWTs.VerifiedJWT{VerifierTestClaims}
+        @test typed_verified.claims.sub == "subject-1"
+        @test typed_verified.claims.exp == 1100
+        @test typed_verified.claims.aud == base_payload["aud"] || typed_verified.claims.aud == [base_payload["aud"]]
+        # a missing required claim is still caught through the struct
+        expired_verifier = Verifier(keyset; algorithms=[algorithm], now=() -> 5000.0, claims=VerifierTestClaims)
+        @test_throws JWTs.JWTClaimError verify(expired_verifier, string(jwt))
+        @test JWTs.claimstype(verifier) === Dict{String,Any}
+    end
 
     vector_audience_verifier = Verifier(keyset; algorithms=[algorithm], audience=["mobile-client", "web-client"], now=() -> 1000.0)
     @test verify(vector_audience_verifier, signed(base_payload)).claims == base_payload

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -443,6 +443,7 @@ function test_verifier_claims(keyset_url)
         typed_payload["aud"] = "api://default"
         typed_jwt = signed(typed_payload)
         typed_verifier = Verifier(
+            VerifierTestClaims,
             keyset;
             algorithms=[algorithm],
             issuer="https://issuer.example",
@@ -452,7 +453,6 @@ function test_verifier_claims(keyset_url)
             nonce="nonce-1",
             required_claims=["exp", "nbf", "iat"],
             now=() -> 1000.0,
-            claims=VerifierTestClaims,
         )
         @test JWTs.claimstype(typed_verifier) === VerifierTestClaims
         typed_verified = verify(typed_verifier, string(typed_jwt))
@@ -468,6 +468,17 @@ function test_verifier_claims(keyset_url)
 
     vector_audience_verifier = Verifier(keyset; algorithms=[algorithm], audience=["mobile-client", "web-client"], now=() -> 1000.0)
     @test verify(vector_audience_verifier, signed(base_payload)).claims == base_payload
+
+    null_audience = copy(base_payload)
+    null_audience["aud"] = nothing
+    null_audience_error = try
+        verify(verifier, signed(null_audience))
+        nothing
+    catch err
+        err
+    end
+    @test null_audience_error isa JWTs.JWTClaimError
+    @test null_audience_error.code === :claim_type
 
     string_audience_payload = copy(base_payload)
     string_audience_payload["aud"] = "api://default"
@@ -570,6 +581,17 @@ function test_remote_jwks_and_oidc()
     @test verify(verifier, string(jwt1)).claims == payload
     @test fetch_counts[jwks_uri] == 1
 
+    typed_remote = Verifier(VerifierTestClaims;
+        jwks_uri=jwks_uri,
+        algorithms=["RS256"],
+        issuer=issuer,
+        audience="api://default",
+        fetcher=_ -> doc1,
+        now=clock,
+    )
+    @test JWTs.claimstype(typed_remote) === VerifierTestClaims
+    @test verify(typed_remote, jwt1).claims.sub == "remote-user"
+
     clock.value += 61
     @test verify(verifier, jwt1).claims == payload
     @test fetch_counts[jwks_uri] == 2
@@ -630,6 +652,18 @@ function test_remote_jwks_and_oidc()
     @test verify(oidc_verifier, jwt2).claims == payload
     @test discovery_counts[discovery_url] == 1
     @test discovery_counts[jwks_uri] == 1
+
+    typed_oidc = Verifier(
+        VerifierTestClaims,
+        issuer;
+        algorithms=["RS256"],
+        audience="api://default",
+        fetcher=url -> url == discovery_url ?
+            Dict("issuer" => issuer, "jwks_uri" => jwks_uri) : doc2,
+        now=clock,
+    )
+    @test JWTs.claimstype(typed_oidc) === VerifierTestClaims
+    @test verify(typed_oidc, jwt2).claims.sub == "remote-user"
     @test verify(oidc_verifier, jwt2).claims == payload
     @test discovery_counts[discovery_url] == 1
     @test discovery_counts[jwks_uri] == 1
@@ -768,5 +802,54 @@ end
         end
         @test missing_iss_err isa JWTs.JWTClaimError
         @test missing_iss_err.code === :claim_missing
+
+        critical_header = JWTs.base64url_encode(JSON.json(Dict{String,Any}(
+            "alg" => "HS256",
+            "kid" => oct_kid,
+            "crit" => ["example"],
+            "example" => true,
+        )))
+        critical_data = critical_header * "." * signed_token.payload
+        critical_signature = JWTs.base64url_encode(
+            JWTs.signbytes(oct_keyset.keys[oct_kid], critical_data),
+        )
+        critical_token = JWT(join((critical_header, signed_token.payload, critical_signature), "."))
+        critical_error = try
+            verify(plain_verifier, critical_token)
+            nothing
+        catch err
+            err
+        end
+        @test critical_error isa JWTs.JWTVerificationError
+        @test critical_error.code === :critical_header_unsupported
+
+        null_critical_header = JWTs.base64url_encode(JSON.json(Dict{String,Any}(
+            "alg" => "HS256",
+            "kid" => oct_kid,
+            "crit" => nothing,
+        )))
+        null_critical_data = null_critical_header * "." * signed_token.payload
+        null_critical_signature = JWTs.base64url_encode(
+            JWTs.signbytes(oct_keyset.keys[oct_kid], null_critical_data),
+        )
+        null_critical_token = JWT(join(
+            (null_critical_header, signed_token.payload, null_critical_signature),
+            ".",
+        ))
+        @test_throws JWTs.JWTVerificationError verify(plain_verifier, null_critical_token)
+
+        b64_header = JWTs.base64url_encode(JSON.json(Dict{String,Any}(
+            "alg" => "HS256",
+            "kid" => oct_kid,
+            "b64" => false,
+        )))
+        b64_data = b64_header * "." * signed_token.payload
+        b64_signature = JWTs.base64url_encode(
+            JWTs.signbytes(oct_keyset.keys[oct_kid], b64_data),
+        )
+        b64_token = JWT(join((b64_header, signed_token.payload, b64_signature), "."))
+        @test_throws JWTs.JWTVerificationError verify(plain_verifier, b64_token)
+
+        @test_throws ArgumentError Verifier(Any, oct_keyset; algorithms=["HS256"])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -760,6 +760,58 @@ end
         @test JWTs.is_http_url("http://issuer.example/keys")
         @test !JWTs.is_http_url("file:///etc/passwd")
 
+        fallback_header = JWTs.decode_jwt_header_claims_untyped(
+            JWTs.base64url_encode(JSON.json(Dict{String,Any}(
+                "alg" => "HS256",
+                "kid" => "fallback-key",
+                "typ" => "JWT",
+                "crit" => ["example"],
+                "b64" => false,
+            ))),
+        )
+        @test fallback_header.alg == "HS256"
+        @test fallback_header.kid == "fallback-key"
+        @test fallback_header.typ == "JWT"
+        @test fallback_header.crit == ["example"]
+        @test fallback_header.b64 === false
+        @test JWTs.jwt_string_array_claim(Dict{String,Any}(), "crit") === nothing
+        @test ismissing(JWTs.jwt_string_array_claim(Dict{String,Any}("crit" => nothing), "crit"))
+        @test_throws ArgumentError JWTs.jwt_string_array_claim(Dict{String,Any}("crit" => "bad"), "crit")
+        @test_throws ArgumentError JWTs.jwt_string_array_claim(Dict{String,Any}("crit" => Any[1]), "crit")
+        @test JWTs.jwt_bool_claim(Dict{String,Any}(), "b64") === nothing
+        @test ismissing(JWTs.jwt_bool_claim(Dict{String,Any}("b64" => nothing), "b64"))
+        @test JWTs.jwt_bool_claim(Dict{String,Any}("b64" => true), "b64")
+        @test_throws ArgumentError JWTs.jwt_bool_claim(Dict{String,Any}("b64" => 1), "b64")
+
+        parsed_keys = Dict{String,Any}(
+            "keys" => Any[Dict{String,Any}("kid" => "parsed-key")],
+        )
+        @test JWTs.fetched_jwks_keys(parsed_keys, "parsed fixture") === parsed_keys["keys"]
+        untyped_keys = JWTs.fetched_jwks_keys_untyped(JSON.json(parsed_keys), "JSON fixture")
+        @test only(untyped_keys)["kid"] == "parsed-key"
+        @test_throws ArgumentError JWTs.fetched_jwks_keys_untyped("[]", "array fixture")
+        @test_throws ArgumentError JWTs.fetched_jwks_keys_untyped("{}", "missing fixture")
+        @test_throws ArgumentError JWTs.fetched_jwks_keys(1, "invalid fixture")
+
+        default_algs = Dict("RSA" => "RS256", "oct" => "HS256")
+        @test JWTs.default_jwk_alg(
+            JWTs.JWKSKey(; kty="EC", crv="P-256"),
+            default_algs,
+        ) == "ES256"
+        @test_throws ArgumentError JWTs.fetch_url("file:///unused"; downloader=:unsupported)
+
+        http_server = JWTs.HTTP.serve!("127.0.0.1", 0; listenany=true) do request
+            request.target == "/keys" && return JWTs.HTTP.Response(200, "jwks-body")
+            return JWTs.HTTP.Response(404, "missing")
+        end
+        try
+            http_base = "http://127.0.0.1:$(JWTs.HTTP.port(http_server))"
+            @test JWTs.fetch_url(http_base * "/keys") == "jwks-body"
+            @test_throws ErrorException JWTs.fetch_url(http_base * "/missing")
+        finally
+            close(http_server)
+        end
+
         # a remote JWKS must not yield a symmetric (forge-able) key
         secret = collect(codeunits("remote-symmetric-secret"))
         sym_doc = Dict("keys" => [Dict("kid" => "sym1", "kty" => "oct", "alg" => "HS256", "k" => JWTs.base64url_encode(secret))])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,7 +80,10 @@ const test_payload_data = [
 Base.@kwdef struct VerifierTestClaims
     iss::Union{Nothing,String} = nothing
     sub::Union{Nothing,String} = nothing
-    aud::Union{Nothing,String,Vector{String}} = nothing
+    # One concrete arm, matching how issuers write a single audience; a
+    # two-arm String|Vector{String} union also works but is not fully static
+    # under juliac --trim on registered StructUtils.
+    aud::Union{Nothing,String} = nothing
     exp::Union{Nothing,Int64} = nothing
     nbf::Union{Nothing,Int64} = nothing
     iat::Union{Nothing,Int64} = nothing
@@ -432,8 +435,13 @@ function test_verifier_claims(keyset_url)
     @test verify(verifier, jwt).claims == base_payload
 
     # An application-declared claims struct: the payload is decoded straight
-    # into it and every validation read is a typed field access.
+    # into it and every validation read is a typed field access. The struct
+    # commits to one aud arm (String), so the token it decodes is signed with
+    # the single-audience form.
     if applicable(JSON.parse, "", VerifierTestClaims)
+        typed_payload = copy(base_payload)
+        typed_payload["aud"] = "api://default"
+        typed_jwt = signed(typed_payload)
         typed_verifier = Verifier(
             keyset;
             algorithms=[algorithm],
@@ -447,14 +455,14 @@ function test_verifier_claims(keyset_url)
             claims=VerifierTestClaims,
         )
         @test JWTs.claimstype(typed_verifier) === VerifierTestClaims
-        typed_verified = verify(typed_verifier, string(jwt))
+        typed_verified = verify(typed_verifier, string(typed_jwt))
         @test typed_verified isa JWTs.VerifiedJWT{VerifierTestClaims}
         @test typed_verified.claims.sub == "subject-1"
         @test typed_verified.claims.exp == 1100
-        @test typed_verified.claims.aud == base_payload["aud"] || typed_verified.claims.aud == [base_payload["aud"]]
+        @test typed_verified.claims.aud == "api://default"
         # a missing required claim is still caught through the struct
         expired_verifier = Verifier(keyset; algorithms=[algorithm], now=() -> 5000.0, claims=VerifierTestClaims)
-        @test_throws JWTs.JWTClaimError verify(expired_verifier, string(jwt))
+        @test_throws JWTs.JWTClaimError verify(expired_verifier, string(typed_jwt))
         @test JWTs.claimstype(verifier) === Dict{String,Any}
     end
 

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -194,6 +194,7 @@ function _run_trim_case(package_project_path::String, juliac_project_path::Strin
             run_path = _trim_output_path(run_dir, output_name)
             @test exit_code == 0
             @test isfile(run_path)
+            exit_code == 0 && isfile(run_path) || return nothing
             run_cmd = `$(abspath(run_path))`
             run_exit, run_output, run_timed_out = _run_trim_executable(run_cmd)
             run_timed_out && _trim_timeout_error("executable run", script_file, run_output)


### PR DESCRIPTION
Makes every decode on the verification path concretely typed, so a server compiled with `juliac --trim=safe` verifies with zero JWTs-owned errors (JuliaCon 2026 workshop app; the residual set there is now Base toolchain machinery only). Five commits, each keeping the default dynamic path unchanged:

**`Verifier{S,F}` → parametric on key source and clock** (earlier commits): a verifier over a static keyset no longer reaches the remote-JWKS machinery statically, and remote key sets are fetched with HTTP.jl instead of Downloads (the `downloader` keyword is accepted and ignored; `fetcher` remains the customization point) — dropping libcurl from every consumer.

**Application-declared claims type**: `Verifier(...; claims=MyClaims)` decodes payloads with `JSON.parse(payload, MyClaims)`, and every validation read goes through one accessor seam (`claimvalue`/`hasclaim`: dict lookup or struct field), so `claim_string`/`claim_number`/`claim_audiences` never see an `Any`. `VerifiedJWT{C}` carries the typed claims; `claimstype(verifier)` reports it; the default remains `Dict{String,Any}`. Mirrors the store-side design in JuliaServices/OAuth.jl#46.

**Typed JOSE header**: `JWTHeaderClaims` gains the registered `typ` member and `verify` decodes headers into it (with the pre-JSON-1 dict fallback the code already used for `jwt_header_string_claim`). `VerifiedJWT.header` is now a `JWTHeaderClaims` — a public field type change.

**Typed JWKS documents**: fetched key-set documents parse as `JWKSDocument{keys::Vector{JWKSKey}}`, where `JWKSKey` is one optional `String` per RFC 7517/7518 member the refresh reads (unknown members like `x5c` are skipped). `refresh!`/`default_jwk_alg` read members through a two-method seam — the public `Vector`-of-dicts path keeps its exact `KeyError`/`TypeError` behavior; the typed path constant-folds to field accesses. The custom-`fetcher` arm and pre-JSON-1 fallback stay dynamic by design. Note for reviewers: a first cut typed the keys as `Vector{Dict{String,Any}}`, which made things far worse under trim (`Dict{String,Any}` as a typed-parse target drags `make(::Type{Any})` and its error-display machinery into the graph) — the member struct is the shape that verifies.

Suite green throughout, including the package's own trim harness; a typed-verifier test covers the declared-claims path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up

- Use the type-first `Verifier(MyClaims, ...)` API for static claim types. No `Val` API is used.
- Reject unsupported JOSE critical and unencoded-payload headers.
- Preserve missing versus null audience errors and cover remote typed verifiers.
- Raise the Julia floor to 1.10 to match HTTP 2.
- Keep the 32-bit package job, but skip Reseau's unsupported precompile workload on that architecture.

Validation: Julia 1.10 and current suites pass. The current suite has 2,704 checks. The typed verification trim workload builds and runs with zero verifier errors. A clean local coverage run reports 100% coverage for changed source lines.

Co-authored by Codex